### PR TITLE
Morphology Correlation Function

### DIFF
--- a/Morphology.cpp
+++ b/Morphology.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Michael C. Heiber
+// Copyright (c) 2017 Michael C. Heiber
 // This source file is part of the Ising_OPV project, which is subject to the MIT License.
 // For more information, see the LICENSE file that accompanies this package.
 

--- a/Morphology.cpp
+++ b/Morphology.cpp
@@ -106,7 +106,7 @@ double Morphology::calculateAdditionalEnergyChange(long int main_site_index,long
                         continue;
                     }
                 }
-                calculateDZ(z1,k);
+                dz = calculateDZ(z1,k);
                 // Count the number of similar neighbors
                 if(lattice[getSite(x1,y1,z1+k+dz)].type==site1_type){
                     count1_i++;
@@ -315,6 +315,11 @@ bool Morphology::calculateAnisotropy(char site_type,int cutoff_distance,int N_sa
             Domain_anisotropy2 = -1;
         }
         return false;
+    }
+    if(4*correlation_length_x>Length || 4*correlation_length_y>Width){
+        cout << "Warning.  Correlation length in x- or y-direction is greater than L/4." << endl;
+        cout << "x-direction correlation length is " << correlation_length_x << "." << endl;
+        cout << "y-direction correlation length is " << correlation_length_y << "." << endl;
     }
     if(site_type==(char)1){
         Domain_anisotropy1 = (2*correlation_length_z)/(correlation_length_x+correlation_length_y);

--- a/Morphology.h
+++ b/Morphology.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Michael C. Heiber
+// Copyright (c) 2017 Michael C. Heiber
 // This source file is part of the Ising_OPV project, which is subject to the MIT License.
 // For more information, see the LICENSE file that accompanies this software.
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Michael C. Heiber
+// Copyright (c) 2017 Michael C. Heiber
 // This source file is part of the Ising_OPV project, which is subject to the MIT License.
 // For more information, see the LICENSE file that accompanies this software.
 
@@ -61,7 +61,7 @@ int main(int argc, char * argv[]){
     // Input parameters
     Input_Parameters parameters;
     // Internal parameters
-    string version = "v3.0";
+    string version = "v3.1";
     bool enable_import_morphology;
     double mix_ratio = 0;
     double domain_size1 = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char * argv[]){
     ofstream morphology_output_file;
     ofstream morphology_cross_section_file;
     ofstream correlationfile_avg;
+    ofstream correlationfile;
     ofstream interfacial_dist_hist_file;
     ofstream tortuosity_hist_file;
     ofstream path_data1_file;
@@ -316,11 +317,20 @@ int main(int argc, char * argv[]){
         if(success){
             domain_size1 = morph.getDomainSize((char)1);
             domain_size2 = morph.getDomainSize((char)2);
+            ss << path << "correlation_data_" << procid << ".txt";
+            correlationfile.open(ss.str().c_str());
+            ss.str("");
+            vector<double> correlation_data1 = morph.getCorrelationData((char)1);
+            vector<double> correlation_data2 = morph.getCorrelationData((char)2);
+            for(int i=0;i<correlation_data1.size();i++){
+                correlationfile << 0.5*(double)i << "," << correlation_data1[i] << "," << correlation_data2[i] << endl;
+            }
+            correlationfile.close();
         }
         success = false;
         cout << procid << ": Calculating the domain anisotropy..." << endl;
         while(!success){
-            if(2*cutoff_distance>morph.getLength() || 2*cutoff_distance>morph.getWidth() || 2*cutoff_distance>morph.getHeight()){
+            if(2*cutoff_distance>morph.getLength() && 2*cutoff_distance>morph.getWidth() && 2*cutoff_distance>morph.getHeight()){
                 break;
             }
             success = morph.calculateAnisotropies(cutoff_distance,parameters.N_sampling_max);
@@ -329,6 +339,9 @@ int main(int argc, char * argv[]){
         if(success){
             domain_anisotropy1 = morph.getDomainAnisotropy((char)1);
             domain_anisotropy2 = morph.getDomainAnisotropy((char)2);
+        }
+        else{
+            cout << procid << ": Warning! Could not calculate the domain anisotropy." << endl;
         }
     }
     // Calculate interfacial distance histogram if enabled.
@@ -621,7 +634,7 @@ int main(int argc, char * argv[]){
                 ss.str("");
             }
         }
-        analysis_file << "Summary of results for this morphology set containing " << nproc <<" morphologies created using Ising_OPV " << version << ":\n" << endl;
+        analysis_file << "Summary of results for this morphology set containing " << nproc <<" morphologies created using Ising_OPV " << version << ":" << endl;
         analysis_file << "length,width,height,mix_ratio_avg,mix_ratio_stdev,domain1_size_avg,domain1_size_stdev,domain2_size_avg,domain2_size_stdev,";
         analysis_file << "domain1_anisotropy_avg,domain1_anisotropy_stdev,domain2_anisotropy_avg,domain2_anisotropy_stdev,";
         analysis_file << "interfacial_area_volume_ratio_avg,interfacial_area_volume_ratio_stdev,interfacial_volume_ratio_avg,interfacial_volume_ratio_stdev,";


### PR DESCRIPTION
-added output of correlation function data for each morphology
-updated failure rules for domain anisotropy calculation
-corrected bug calculating dz in the calculateAdditionalEnergyChange
function
-added warning output to calculateAdditonalEnergyChange function when
the lateral dimensions of the lattice might be too small for the given
anisotropy