### PR TITLE
v3.2 Update

### DIFF
--- a/Morphology.cpp
+++ b/Morphology.cpp
@@ -2005,6 +2005,11 @@ bool Morphology::importMorphologyFile(ifstream * input,bool compressed_files){
     string line;
     Site site;
     getline(*input,line);
+    if(line.substr(0,9).compare("Ising_OPV")==0){
+        // skip first line
+        // get next line
+        getline(*input,line);
+    }
     Length = atoi(line.c_str());
     getline(*input,line);
     Width = atoi(line.c_str());

--- a/main.cpp
+++ b/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char * argv[]){
     // Input parameters
     Input_Parameters parameters;
     // Internal parameters
-    string version = "v3.1";
+    string version = "v3.2";
     bool enable_import_morphology;
     double mix_ratio = 0;
     double domain_size1 = 0;
@@ -380,11 +380,13 @@ int main(int argc, char * argv[]){
                 ss << path << "morphology_" << procid << "_uncompressed.txt";
                 morphology_output_file.open(ss.str().c_str());
                 ss.str("");
+                morphology_output_file << "Ising_OPV " << version << " - uncompressed format" << endl;
             }
             else{
                 ss << path << "morphology_" << procid << "_compressed.txt";
                 morphology_output_file.open(ss.str().c_str());
                 ss.str("");
+                morphology_output_file << "Ising_OPV " << version << " - compressed format" << endl;
             }
         }
         else{
@@ -392,11 +394,13 @@ int main(int argc, char * argv[]){
                 ss << path << filename_prefix << "mod_" << procid << "_uncompressed.txt";
                 morphology_output_file.open(ss.str().c_str());
                 ss.str("");
+                morphology_output_file << "Ising_OPV " << version << " - uncompressed format" << endl;
             }
             else{
                 ss << path << filename_prefix << "mod_" << procid << "_compressed.txt";
                 morphology_output_file.open(ss.str().c_str());
                 ss.str("");
+                morphology_output_file << "Ising_OPV " << version << " - compressed format" << endl;
             }
         }
         morph.outputMorphologyFile(&morphology_output_file,parameters.enable_export_compressed_files);

--- a/parameters_default.txt
+++ b/parameters_default.txt
@@ -1,4 +1,4 @@
-## Parameters for Ising_OPV v3.0
+## Parameters for Ising_OPV v3.2
 -------------------------------
 ## General Parameters
 50 //length (integer values only) (specify the x-direction size of the lattice)


### PR DESCRIPTION
Updated morphology output so that the first line of the morphology file contains information about the version of Ising_OPV used to generate the morphology and whether the file is compressed or uncompressed.