### PR TITLE
Development Update 3

### DIFF
--- a/Morphology.h
+++ b/Morphology.h
@@ -36,8 +36,15 @@ struct NeighborInfo{
     char total3;
 };
 
+struct CorrelationCalcParams {
+	int N_sampling_max;
+	bool Enable_mix_frac_method;
+	bool Enable_e_method;
+	bool Enable_extended_correlation_calc;
+	int Correlation_cutoff_distance;
+};
+
 struct TomogramImportParams {
-	// Tomogram Import Options
 	bool Enable_cutoff_analysis;
 	int Mixed_greyscale_width;
 	double Mixed_conc;
@@ -54,10 +61,10 @@ public:
 	Morphology(const Lattice& input_lattice, const int id);
     virtual ~Morphology();
     bool calculateAnisotropies(const int N_sampling_max);
-	void calculateCorrelationDistances(const bool enable_extended_calc, const int N_sampling_max);
+	void calculateCorrelationDistances(const CorrelationCalcParams& parameters);
+	void calculateDepthDependentData(const CorrelationCalcParams& correlation_params);
     double calculateInterfacialAreaVolumeRatio() const;
     bool calculateInterfacialDistance();
-    //bool calculateInterfacialDistanceOld();
     double calculateInterfacialVolumeFraction() const;
 	void calculateMixFractions();
     bool calculateTortuosity(const bool enable_reduced_memory);
@@ -68,6 +75,8 @@ public:
     void executeMixing(const double width, const double interfacial_conc);
     void executeSmoothing(const double smoothing_threshold, const int rescale_factor);
     std::vector<double> getCorrelationData(const char site_type) const;
+	std::vector<double> getDepthCompositionData(const char site_type) const;
+	std::vector<double> getDepthDomainSizeData(const char site_type) const;
     double getDomainSize(const char site_type) const;
     double getDomainAnisotropy(const char site_type) const;
     int getHeight() const;
@@ -108,7 +117,7 @@ private:
     };
     // properties
     int ID;
-    std::vector<double> Mix_fractions; // Fraction of each component to total
+    std::vector<double> Mix_fractions; // Volume fraction of each component to total
     bool Enable_third_neighbor_interaction;
 	Lattice lattice;
 	std::vector<char> Site_types;
@@ -117,13 +126,13 @@ private:
 	std::vector<std::vector<float>> Tortuosity_data;
 	std::vector<std::vector<double>> InterfacialHistogram_data;
 	std::vector<std::vector<double>> TortuosityHistogram_data;
-    std::vector<bool> Domain_size_updated;
+	std::vector<std::vector<double>> Depth_composition_data;
+	std::vector<std::vector<double>> Depth_domain_size_data;
     std::vector<bool> Domain_anisotropy_updated;
-    std::vector<double> Domain_size;
-    std::vector<double> Domain_anisotropy;
+    std::vector<double> Domain_sizes;
+    std::vector<double> Domain_anisotropies;
     std::vector<int> Island_volume;
 	std::vector<long int> Interfacial_sites;
-	std::vector<std::vector<long int>> Correlation_sites_data;
 	std::vector<NeighborCounts> Neighbor_counts;
 	std::vector<NeighborInfo> Neighbor_info;
     NeighborCounts Temp_counts1;
@@ -132,8 +141,8 @@ private:
     // functions
 	void addSiteType(const char site_type);
     double calculateAdditionalEnergyChange(const long int site_index_main, const long int site_index_neighbor,const int growth_direction,const double additional_interaction) const;
-    bool calculateAnisotropy(const char site_type,const int cutoff_distance,const int N_sampling_max);
-	bool calculateCorrelationDistance(const char site_type, const int cutoff_distance, const bool enable_extended_calc, const int N_sampling_max);
+    bool calculateAnisotropy(const std::vector<long int>& correlation_sites, const char site_type,const int cutoff_distance);
+	double calculateCorrelationDistance(const std::vector<long int>& correlation_sites, std::vector<double>& correlation_data, const char site_type, const int cutoff_distance, const CorrelationCalcParams& params);
     double calculateDissimilarFraction(const Coords& coords, const int rescale_factor) const;
     double calculateEnergyChangeSimple(const long int site_index1, const long int site_index2, const double interaction_energy1, const double interaction_energy2);
     double calculateEnergyChange(const Coords& coords1, const Coords& coords2,const double interaction_energy1,const double interaction_energy2) const;
@@ -142,6 +151,7 @@ private:
     bool calculatePathDistances_ReducedMemory(std::vector<float>& path_distances);
     void createNode(Node& node,const Coords& coords);
     void getSiteSampling(std::vector<long int>& sites, const char site_type, const int N_sites);
+	void getSiteSamplingZ(std::vector<long int>& sites, const char site_type, const int N_sites, const int z);
 	int getSiteTypeIndex(const char site_type) const;
     void initializeNeighborInfo();
 	bool isNearInterface(const Coords& coords, const double distance) const;

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -20,7 +20,8 @@ namespace Utils {
 
 	vector<pair<double, double>> calculateProbabilityHist(const vector<double>& data, int num_bins) {
 		// Determine data range
-		double min_val, max_val;
+		double min_val = 0;
+		double max_val = 0;
 		auto min_it = min_element(data.begin(), data.end());
 		if (min_it != data.end()) {
 			min_val = *min_it;
@@ -46,7 +47,8 @@ namespace Utils {
 
 	vector<pair<double, double>> calculateProbabilityHist(const vector<double>& data, double bin_size) {
 		// Determine data range
-		double min_val, max_val;
+		double min_val = 0;
+		double max_val = 0;
 		auto min_it = min_element(data.begin(), data.end());
 		if (min_it != data.end()) {
 			min_val = *min_it;
@@ -73,7 +75,7 @@ namespace Utils {
 
 	vector<pair<double, double>> calculateProbabilityHist(const vector<double>& data, const double bin_size, const int num_bins) {
 		// Determine number of bins
-		double min_val;
+		double min_val = 0;
 		auto min_it = min_element(data.begin(), data.end());
 		if (min_it != data.end()) {
 			min_val = *min_it;

--- a/Utils.h
+++ b/Utils.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <memory>
 #include <mpi.h>
+#include <fstream>
 #include <random>
 #include <set>
 #include <string>
@@ -187,8 +188,7 @@ namespace Utils {
 
 	template<typename T>
 	T array_median(const T data[], const int array_size) {
-		T element;
-		std::vector<T> data_vect(array_size, element);
+		std::vector<T> data_vect(array_size);
 		for (int i = 0; i<array_size; i++) {
 			data_vect[i] = data[i];
 		}
@@ -244,7 +244,7 @@ namespace Utils {
 	//! \param filename is the input file name.
 	template<typename T>
 	void outputVectorToFile(std::vector<T>& vec, std::string filename) {
-		ofstream outfile;
+		std::ofstream outfile;
 		outfile.open(filename);
 		for (int i = 0; i < (int)vec.size(); i++) {
 			outfile << vec[i] << "\n";
@@ -258,7 +258,7 @@ namespace Utils {
 	//! \param filename is the input file name.
 	template<typename T>
 	void outputVectorToFile(std::vector<std::pair<T,T>>& vec, std::string filename) {
-		ofstream outfile;
+		std::ofstream outfile;
 		outfile.open(filename);
 		for (int i = 0; i < (int)vec.size(); i++) {
 			outfile << vec[i].first << "," << vec[i].second << "\n";

--- a/makefile
+++ b/makefile
@@ -1,2 +1,21 @@
-Ising_OPV.exe : main.cpp Morphology.cpp
-	mpicxx -o Ising_OPV.exe main.cpp Morphology.cpp -Wall -Wextra -O2
+COMPILER = mpicxx
+FLAGS = -Wall -Wextra -O3 -std=c++11
+OBJS = main.o Morphology.o Lattice.o Utils.o
+
+Ising_OPV.exe : $(OBJS)
+	$(COMPILER) $(FLAGS) $(OBJS) -o Ising_OPV.exe
+
+main.o : main.cpp Morphology.h Lattice.h Utils.h
+	$(COMPILER) $(FLAGS) -c main.cpp
+	
+Morphology.o : Morphology.h Morphology.cpp Lattice.h Utils.h
+	$(COMPILER) $(FLAGS) -c Morphology.cpp
+
+Lattice.o : Lattice.h Lattice.cpp Utils.h
+	$(COMPILER) $(FLAGS) -c Lattice.cpp
+	
+Utils.o : Utils.h Utils.cpp
+	$(COMPILER) $(FLAGS) -c Utils.cpp
+	
+clean:
+	\rm *.o *~ Ising_OPV.exe

--- a/parameters_default.txt
+++ b/parameters_default.txt
@@ -32,10 +32,14 @@ false //enable_interfacial_mixing (true or false) (choose whether or not to intr
 false //enable_analysis_only (true or false)
 true //enable_correlation_calc (true or false) (choose whether or not to calculate the domain size using the pair-pair correlation method)
 100000 //N_sampling_max (specify the maximum number of sites to randomly sample for the correlation calculation)
+false //enable_mix_frac_method
+true //enable_e_method
 false //enable_extended_correlation_calc (true of false) (choose whether or not to extend the correlation function calculation to the second correlation maximum)
+10 // Correlation_cutoff_distance
 true //enable_interfacial_distance_calc (true of false) (choose whether or not to calculate the interfacial distance histograms)
 true //enable_tortuosity_calc (true or false) (choose whether or not to determine the tortuosity histograms, calculate the island volume fraction, and collect the end-to-end path data)
 false //enable_reduced_memory_tortuosity_calc (true or false) (choose whether or not to enable a tortuosity calculation method that takes longer, but uses less memory)
+true //enable_depth_dependent_calc
 -------------------------------
 ## Other Options
 false //enable_checkerboard_start (creates a 50:50 blend, works best with even lattice dimensions)


### PR DESCRIPTION
makefile:
-updated makefile to include compilation of new Lattice and Utils files
-added separate commands for compiling each object file
-added a clean command that deletes the object files and executable

parameters_default:
-added new input parameters to allow the user to determine whether they
want to use the mix fraction method or the 1/e method for determining
the domain size
-added Correlation_cutoff_distance parameter to define how much to
extend the correlation function calculation
-added Enable_depth_dependent_calc parameter to enable the depth
dependent blend composition and domain size calculations

main:
-added new input parameters to allow the user to determine whether they
want to use the mix fraction method or the 1/e method for determining
the domain size
-added Correlation_cutoff_distance parameter to define how much to
extend the correlation function calculation
-added Enable_depth_dependent_calc parameter to enable the depth
dependent blend composition and domain size calculations
-updated importParameters function to take a CorrelationCalcParams
object as an argument by reference so that these parameters can be
assigned from the parameter file
-added vectors to store depth dependent composition and domain size data
-added an output filestream for the average depth dependent data
-fixed bug with interpreting command line arguments when not importing
morphologies
-added calculation of depth dependent blend composition and domain size
and averaging of each data set for site types 1 and 2 for the whole
morphology set

Morphology class:
-added new CorrelationCalcParams struct to contain all of the parameters
needed for the correlation function calculation
-updated calculateCorrelationDistances function to accept a
CorrelationCalcParams struct instead of individual parameters
-added calculateDepthDependentData function to calculate the blend
compsition and domain size as a function of film depth in the
z-direction
-added getDepthCompositionData and getDepthDomainSizeData function to
access the depth dependent data for the specified site type
-added member vectors Depth_composition_data and Depth_domain_size_data
to store the depth dependent data for each site type
-removed member vectors Domain_size_updated and Correlation_sites_data
because these data structures are no longer needed at class scope and
are instead kept within the calculateCorrelationDistances function scope
-updated calculateAnisotropy function to accept a correlation_sites
vector instead of using the old Correlation_size_data vector and removed
the N_sample_max input parameter that was no longer needed
-updated calculateCorrelationDistance function to accept a
correlation_sites vector instead of using the old Correlation_size_data
vector, a correlation_data vector instead of using the class level
Correlation_data vector, and replaced the N_sample_max input parameter
with the more complete CorrelationCalcParams struct
-updated calculateCorrelationDistance function to return the calculated
domain size instead of a bool value, and the function returns -1 if
there is a problem

Utils:
-added include statement for fstream
-removed uneeded parameter declaration in array_median template function
-added std:: namespace designation to the ofstream object typename
-added initialization of values to avoid possible use of unitialized
variables
-added getSiteSamplingZ function to sample sites from an x-y slice with
a given z value
-updated calculateAnisotropies to create and manage the
correlation_sites_data that is passed to the calculateAnisotropy
function