### PR TITLE
Tomogram Import Bugfix and Compiler Warning Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - README.md - Link to JOSS paper
+- Morphology (executeIsingSwapping) - Cast return of distance function to an int to prevent compiler warning
+- Morphology (importTomogramMorphologyFile) - Cast return of ifstream's tellg function to an int to prevent compiler warning
+- Utils (vector_which_median) - Cast return of distance function to int to prevent compiler warning
 
 ### Changed
 - Doxyfile - Updated file input and output paths to relative paths
 - Version - Updated Current_version namespace variable to v4.0.1
 - Updated Doxygen documentation
+- Morphology (calculatePathDistances) - Moved declaration of local z variable near it's first use to prevent potential conflict with other z variable used in a subsequent loop
+- main.cpp (main) - Imported morphology filenames now use main's reusable filename string variable
 
 ### Fixed
 - Morphology (importTomogramMorphologyFile) - Corrected error loading xml metadata files on Windows by telling the fopen function to open the file as a binary file
 - Morphology (importTomogramMorphologyFile) - Corrected miscalculation of the extracted sublattice dimensions that was causing some tomogram files not to be imported
+- Parameters (importParameters) - Corrected problem importing the Mixed_frac parameter from the parameter file as an integer instead of a double
 
 ## [v4.0.0] - 2018-11-29 - Final Release
 

--- a/src/Morphology.cpp
+++ b/src/Morphology.cpp
@@ -1047,7 +1047,6 @@ namespace Ising_OPV {
 	}
 
 	bool Morphology::calculatePathDistances(vector<float>& path_distances) {
-		int z;
 		Coords coords;
 		long int current_index;
 		long int neighbor_index;
@@ -1092,6 +1091,7 @@ namespace Ising_OPV {
 			}
 		}
 		// The pathfinding algorithm is performed for one domain type at a time.
+		int z;
 		for (int n = 0; n < 2; n++) {
 			// Use Dijkstra's algorithm to fill in the remaining path distance data.
 			cout << ID << ": Executing Dijkstra's algorithm to calculate shortest paths through domain type " << (int)Site_types[n] << ".\n";
@@ -1562,7 +1562,7 @@ namespace Ising_OPV {
 				}
 			});
 			// Select random dissimilar neighbor site
-			uniform_int_distribution<int> dist(0, distance(neighbors.begin(), it) - 1);
+			uniform_int_distribution<int> dist(0, (int)distance(neighbors.begin(), it) - 1);
 			auto selected_it = neighbors.begin();
 			advance(selected_it, dist(gen));
 			neighbor_site_index = *selected_it;
@@ -1915,7 +1915,7 @@ namespace Ising_OPV {
 			throw runtime_error("Error! Tomogram binary RAW file could not be opened.");
 		}
 		data_file.seekg(0, data_file.end);
-		int N_bytes = data_file.tellg();
+		int N_bytes = (int)data_file.tellg();
 		data_file.seekg(0, data_file.beg);
 		vector<float> data_vec;
 		if (data_format.compare("8 bit") == 0) {

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -431,7 +431,7 @@ namespace Ising_OPV {
 		//	Error_found = true;
 		//}
 		//i++;
-		Mixed_frac = atoi(stringvars[i].c_str());
+		Mixed_frac = atof(stringvars[i].c_str());
 		i++;
 		Mixed_conc = atof(stringvars[i].c_str());
 		i++;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -404,7 +404,7 @@ namespace Ising_OPV {
 			diff[i] = fabs(data[i] - median);
 		}
 		auto it = min_element(diff.begin(), diff.end());
-		return distance(diff.begin(), it);
+		return (int)distance(diff.begin(), it);
 	}
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char * argv[]) {
 		MPI_Barrier(MPI_COMM_WORLD);
 	}
 	if (parameters.Enable_import_morphologies || parameters.Enable_import_tomogram) {
-		string filename = "morphology_" + to_string(procid) + ".txt";
+		filename = "morphology_" + to_string(procid) + ".txt";
 		cout << procid << ": Opening morphology file " << filename << endl;
 		morphology_input_file.open(filename);
 		if (morphology_input_file.is_open()) {


### PR DESCRIPTION
- Resolves #16 

General:
-Updated Changelog to note the modification in this bugfix branch

main:
-Update morphology import section to reuse main's filename string variable instead of creating a new local filename variable

Morphology class:
-Updated calculatePathDistances function by moving declaration of local z variable near it's first use to prevent potential conflict with other z variable used in a subsequent loop
-Updated executeIsingSwapping function by casting return of distance function to an int to prevent compiler warning
-Updated importTomogramMorphologyFile function by casting return of ifstream's tellg function to an int to prevent compiler warning

Parameters class:
-Updated importParameters function to correct problem importing the Mixed_frac parameter from the parameter file as an integer instead of a double

Utils:
-Updated vector_which_median template function by casting return of distance function to int to prevent compiler warning